### PR TITLE
support kid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.0"
+        "phpunit/phpunit": "^6.0.0"
     }
 }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -68,7 +68,7 @@ class JWT
      * @param int             $leeway Leeway for clock skew. Shouldnot be more than 2 minutes (120s).
      * @param string          $pass   The passphrase (only for RS* algos).
      */
-    public function __construct($key, string $algo = 'HS256', int $maxAge = 3600, int $leeway = 0, ?string $pass = null)
+    public function __construct($key, string $algo = 'HS256', int $maxAge = 3600, int $leeway = 0, string $pass = null)
     {
         $this->validateConfig($key, $algo, $maxAge, $leeway);
 

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -12,6 +12,8 @@ namespace Ahc\Jwt;
  */
 class JWT
 {
+    use ValidatesJWT;
+
     const ERROR_KEY_EMPTY        = 10;
     const ERROR_KEY_INVALID      = 12;
     const ERROR_ALGO_UNSUPPORTED = 20;
@@ -68,7 +70,7 @@ class JWT
      */
     public function __construct($key, string $algo = 'HS256', int $maxAge = 3600, int $leeway = 0, ?string $pass = null)
     {
-        $this->validate($key, $algo, $maxAge, $leeway);
+        $this->validateConfig($key, $algo, $maxAge, $leeway);
 
         if (\is_array($key)) {
             $this->registerKeys($key);
@@ -249,108 +251,5 @@ class JWT
         $this->validateLastJson();
 
         return $data;
-    }
-
-    /**
-     * Throw up if input parameters invalid.
-     *
-     * @codeCoverageIgnore
-     */
-    protected function validate($key, string $algo, int $maxAge, int $leeway)
-    {
-        if (empty($key)) {
-            throw new \InvalidArgumentException('Signing key cannot be empty', static::ERROR_KEY_EMPTY);
-        }
-
-        if (!isset($this->algos[$algo])) {
-            throw new \InvalidArgumentException('Unsupported algo ' . $algo, static::ERROR_ALGO_UNSUPPORTED);
-        }
-
-        if ($maxAge < 1) {
-            throw new \InvalidArgumentException('Invalid maxAge: Should be greater than 0', static::ERROR_INVALID_MAXAGE);
-        }
-
-        if ($leeway < 0 || $leeway > 120) {
-            throw new \InvalidArgumentException('Invalid leeway: Should be between 0-120', static::ERROR_INVALID_LEEWAY);
-        }
-    }
-
-    /**
-     * Throw up if header invalid.
-     */
-    protected function validateHeader(array $header)
-    {
-        if (empty($header['alg'])) {
-            throw new \InvalidArgumentException('Invalid token: Missing header algo', static::ERROR_ALGO_MISSING);
-        }
-        if (empty($this->algos[$header['alg']])) {
-            throw new \InvalidArgumentException('Invalid token: Unsupported header algo', static::ERROR_ALGO_UNSUPPORTED);
-        }
-
-        $this->validateKid($header);
-    }
-
-    /**
-     * Throw up if kid exists and invalid.
-     */
-    protected function validateKid(array $header)
-    {
-        if (!isset($header['kid'])) {
-            return;
-        }
-        if (empty($this->keys[$header['kid']])) {
-            throw new \InvalidArgumentException('Invalid token: Unknown key ID', static::ERROR_KID_UNKNOWN);
-        }
-
-        $this->key = $this->keys[$header['kid']];
-    }
-
-    /**
-     * Throw up if timestamp claims like iat, exp, nbf are invalid.
-     */
-    protected function validateTimestamps(array $payload)
-    {
-        $timestamp = $this->timestamp ?? \time();
-        if (isset($payload['exp']) && $timestamp >= ($payload['exp'] + $this->leeway)) {
-            throw new \InvalidArgumentException('Invalid token: Expired', static::ERROR_TOKEN_EXPIRED);
-        }
-
-        if (isset($payload['iat']) && $timestamp >= ($payload['iat'] + $this->maxAge - $this->leeway)) {
-            throw new \InvalidArgumentException('Invalid token: Expired', static::ERROR_TOKEN_EXPIRED);
-        }
-
-        if (isset($payload['nbf']) && $timestamp <= ($payload['nbf'] - $this->leeway)) {
-            throw new \InvalidArgumentException('Invalid token: Cannot accept now', static::ERROR_TOKEN_NOT_NOW);
-        }
-    }
-
-    /**
-     * Throw up if key is not resource or file path to private key.
-     */
-    protected function validateKey()
-    {
-        if (\is_string($this->key)) {
-            if (!\is_file($this->key)) {
-                throw new \InvalidArgumentException('Invalid key: Should be file path of private key', static::ERROR_KEY_INVALID);
-            }
-
-            $this->key = \openssl_get_privatekey('file://' . $this->key, $this->passphrase ?? '');
-        }
-
-        if (!\is_resource($this->key)) {
-            throw new \InvalidArgumentException('Invalid key: Should be resource of private key', static::ERROR_KEY_INVALID);
-        }
-    }
-
-    /**
-     * Throw up if last json_encode/decode was a failure.
-     */
-    protected function validateLastJson()
-    {
-        if (JSON_ERROR_NONE === \json_last_error()) {
-            return;
-        }
-
-        throw new \InvalidArgumentException('JSON failed: ' . \json_last_error_msg(), static::ERROR_JSON_FAILED);
     }
 }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -71,8 +71,8 @@ class JWT
         $this->validate($key, $algo, $maxAge, $leeway);
 
         if (\is_array($key)) {
-            $this->keys = $key;
-            $key        = reset($key); // use first one!
+            $this->registerKeys($key);
+            $key = reset($key); // use first one!
         }
 
         $this->key        = $key;
@@ -298,7 +298,6 @@ class JWT
         if (!isset($header['kid'])) {
             return;
         }
-
         if (empty($this->keys[$header['kid']])) {
             throw new \InvalidArgumentException('Invalid token: Unknown key ID', static::ERROR_KID_UNKNOWN);
         }

--- a/src/ValidatesJWT.php
+++ b/src/ValidatesJWT.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Ahc\Jwt;
+
+/**
+ * JSON Web Token (JWT) implementation in PHP7.
+ *
+ * @author   Jitendra Adhikari <jiten.adhikary@gmail.com>
+ * @license  MIT
+ *
+ * @link     https://github.com/adhocore/jwt
+ */
+trait ValidatesJWT
+{
+    /**
+     * Throw up if input parameters invalid.
+     *
+     * @codeCoverageIgnore
+     */
+    protected function validateConfig($key, string $algo, int $maxAge, int $leeway)
+    {
+        if (empty($key)) {
+            throw new \InvalidArgumentException('Signing key cannot be empty', static::ERROR_KEY_EMPTY);
+        }
+
+        if (!isset($this->algos[$algo])) {
+            throw new \InvalidArgumentException('Unsupported algo ' . $algo, static::ERROR_ALGO_UNSUPPORTED);
+        }
+
+        if ($maxAge < 1) {
+            throw new \InvalidArgumentException('Invalid maxAge: Should be greater than 0', static::ERROR_INVALID_MAXAGE);
+        }
+
+        if ($leeway < 0 || $leeway > 120) {
+            throw new \InvalidArgumentException('Invalid leeway: Should be between 0-120', static::ERROR_INVALID_LEEWAY);
+        }
+    }
+
+    /**
+     * Throw up if header invalid.
+     */
+    protected function validateHeader(array $header)
+    {
+        if (empty($header['alg'])) {
+            throw new \InvalidArgumentException('Invalid token: Missing header algo', static::ERROR_ALGO_MISSING);
+        }
+        if (empty($this->algos[$header['alg']])) {
+            throw new \InvalidArgumentException('Invalid token: Unsupported header algo', static::ERROR_ALGO_UNSUPPORTED);
+        }
+
+        $this->validateKid($header);
+    }
+
+    /**
+     * Throw up if kid exists and invalid.
+     */
+    protected function validateKid(array $header)
+    {
+        if (!isset($header['kid'])) {
+            return;
+        }
+        if (empty($this->keys[$header['kid']])) {
+            throw new \InvalidArgumentException('Invalid token: Unknown key ID', static::ERROR_KID_UNKNOWN);
+        }
+
+        $this->key = $this->keys[$header['kid']];
+    }
+
+    /**
+     * Throw up if timestamp claims like iat, exp, nbf are invalid.
+     */
+    protected function validateTimestamps(array $payload)
+    {
+        $timestamp = $this->timestamp ?? \time();
+        if (isset($payload['exp']) && $timestamp >= ($payload['exp'] + $this->leeway)) {
+            throw new \InvalidArgumentException('Invalid token: Expired', static::ERROR_TOKEN_EXPIRED);
+        }
+
+        if (isset($payload['iat']) && $timestamp >= ($payload['iat'] + $this->maxAge - $this->leeway)) {
+            throw new \InvalidArgumentException('Invalid token: Expired', static::ERROR_TOKEN_EXPIRED);
+        }
+
+        if (isset($payload['nbf']) && $timestamp <= ($payload['nbf'] - $this->leeway)) {
+            throw new \InvalidArgumentException('Invalid token: Cannot accept now', static::ERROR_TOKEN_NOT_NOW);
+        }
+    }
+
+    /**
+     * Throw up if key is not resource or file path to private key.
+     */
+    protected function validateKey()
+    {
+        if (\is_string($this->key)) {
+            if (!\is_file($this->key)) {
+                throw new \InvalidArgumentException('Invalid key: Should be file path of private key', static::ERROR_KEY_INVALID);
+            }
+
+            $this->key = \openssl_get_privatekey('file://' . $this->key, $this->passphrase ?? '');
+        }
+
+        if (!\is_resource($this->key)) {
+            throw new \InvalidArgumentException('Invalid key: Should be resource of private key', static::ERROR_KEY_INVALID);
+        }
+    }
+
+    /**
+     * Throw up if last json_encode/decode was a failure.
+     */
+    protected function validateLastJson()
+    {
+        if (JSON_ERROR_NONE === \json_last_error()) {
+            return;
+        }
+
+        throw new \InvalidArgumentException('JSON failed: ' . \json_last_error_msg(), static::ERROR_JSON_FAILED);
+    }
+}

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -5,34 +5,34 @@ namespace Ahc\Jwt\Test;
 use Ahc\Jwt\JWT;
 
 /** @coversDefaultClass \Ahc\Jwt\JWT */
-class JWTTest extends \PHPUnit_Framework_TestCase
+class JWTTest extends \PHPUnit\Framework\TestCase
 {
     /** @dataProvider data1 */
-    public function test_parse_generated_token(string $key, string $algo, int $age, int $leeway, array $payload, array $header = [])
+    public function test_decode_encoded_token(string $key, string $algo, int $age, int $leeway, array $payload, array $header = [])
     {
         $jwt   = new JWT($key, $algo, $age, $leeway);
-        $token = $jwt->generate($payload, $header);
+        $token = $jwt->encode($payload, $header);
 
         $this->assertTrue(is_string($token));
-        $parsed = $jwt->parse($token);
-        $this->assertTrue(is_array($parsed));
+        $decoded = $jwt->decode($token);
+        $this->assertTrue(is_array($decoded));
 
         // Normalize.
         if (!isset($payload['exp'])) {
-            unset($parsed['exp']);
+            unset($decoded['exp']);
         }
 
-        $this->assertSame($payload, $parsed);
+        $this->assertSame($payload, $decoded);
     }
 
     public function test_json_fail()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $jwt = new JWT('very^secre7');
 
         try {
-            $jwt->generate([random_bytes(10)]);
+            $jwt->encode([random_bytes(10)]);
         } catch (\Exception $e) {
             $this->assertSame($e->getCode(), JWT::ERROR_JSON_FAILED, $e->getMessage());
 
@@ -41,19 +41,19 @@ class JWTTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider data2 */
-    public function test_parse_fail(string $key, string $algo, int $age, int $leeway, int $offset, int $error, $token)
+    public function test_decode_fail(string $key, string $algo, int $age, int $leeway, int $offset, int $error, $token)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $jwt   = new JWT($key, $algo, $age, $leeway);
-        $token = is_string($token) ? $token : $jwt->generate($token);
+        $token = is_string($token) ? $token : $jwt->encode($token);
 
         if ($offset) {
             $jwt->setTestTimestamp(time() + $offset);
         }
 
         try {
-            $jwt->parse($token);
+            $jwt->decode($token);
         } catch (\Exception $e) {
             $this->assertSame($e->getCode(), $error, $e->getMessage());
 
@@ -62,28 +62,28 @@ class JWTTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider data1 */
-    public function test_rs_parse_generated(string $key, string $algo, int $age, int $leeway, array $payload, array $header = [])
+    public function test_rs_decode_encoded(string $key, string $algo, int $age, int $leeway, array $payload, array $header = [])
     {
         $key   = __DIR__ . '/stubs/priv.key';
         $jwt   = new JWT($key, str_replace('HS', 'RS', $algo), $age, $leeway);
         $token = $jwt->encode($payload, $header);
 
         $this->assertTrue(is_string($token));
-        $parsed = $jwt->decode($token);
-        $this->assertTrue(is_array($parsed));
+        $decoded = $jwt->decode($token);
+        $this->assertTrue(is_array($decoded));
 
         // Normalize.
         if (!isset($payload['exp'])) {
-            unset($parsed['exp']);
+            unset($decoded['exp']);
         }
 
-        $this->assertSame($payload, $parsed);
+        $this->assertSame($payload, $decoded);
     }
 
     /** @dataProvider data3 */
     public function test_rs_invalid_key(string $method, string $key, $arg)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $jwt = new JWT($key, 'RS256');
 
@@ -179,9 +179,9 @@ class JWTTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['encode', 'not a file', ['uid' => rand()]],
-            ['generate', __FILE__, ['uid' => rand()]],
+            ['encode', __FILE__, ['uid' => rand()]],
             ['decode', 'not a file', 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE0OTIwODkxODksImV4cCI6MTQ5MjA4OTE4OX0.fakesignature'],
-            ['parse', __FILE__, 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE0OTIwODkxODksImV4cCI6MTQ5MjA4OTE4OX0.fakesignature'],
+            ['decode', __FILE__, 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE0OTIwODkxODksImV4cCI6MTQ5MjA4OTE4OX0.fakesignature'],
         ];
     }
 }

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -96,6 +96,30 @@ class JWTTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function test_kid()
+    {
+        $jwt = (new JWT('dummy', 'HS256'))->registerKeys(['key1' => 'secret1', 'key2' => 'secret2']);
+
+        // Use key2
+        $token = $jwt->encode($payload = ['a' => 1, 'exp' => time() + 1000], ['kid' => 'key2']);
+
+        $this->assertSame($payload, $jwt->decode($token));
+
+        return $jwt;
+    }
+
+    public function test_kid_invalid()
+    {
+        // keys can be sent as array too
+        $jwt = new JWT(['key1' => 'secret1', 'key2' => 'secret2'], 'HS256');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid token: Unknown key ID');
+
+        // Use key3
+        $jwt->encode(['a' => 1, 'exp' => time() + 1000], ['kid' => 'key3']);
+    }
+
     public function data1() : array
     {
         return [

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -129,7 +129,7 @@ class JWTTest extends \PHPUnit\Framework\TestCase
                 'msg'    => 'fdsfdsf',
                 'iss'    => 'https://mysite.com',
             ]],
-            ['$ecRet-$ecRet', 'HS384', rand(10, 1000), rand(1, 10), [
+            ['$ecRet-$ecRet', 'HS384', rand(101, 1000), rand(1, 10), [
                 'uid'    => rand(),
                 'scopes' => ['admin'],
                 'exp'    => time() + 100,


### PR DESCRIPTION
closes #3 

- [x] support 'kid'
- [x] add validator
- [x] remove alias `generate()` and `parse()` for favor or `encode()` and `decode()`